### PR TITLE
Improve left nav icon alignment

### DIFF
--- a/template/2/css/style.css
+++ b/template/2/css/style.css
@@ -89,7 +89,7 @@ form {
 	font-size: 14px;
 }
 
-.menuitemsidebar {
+.menuitemsidebar, .menuitemsidebarlong {
 	width: 143px;
 	height: 40px;
 	margin-top: 1px;
@@ -99,28 +99,13 @@ form {
 	transition: background-image 0.125s ease-in-out;
 }
 
-.menuitemsidebarlong {
-	width: 143px;
-	height: 40px;
-	margin-top: 1px;
-	background: url("../images/mainSidebar.png")  no-repeat;
-	-webkit-transition: background-image 0.125s ease-in-out;
-	-o-transition: background-image 0.125s ease-in-out;
-	transition: background-image 0.125s ease-in-out;
-}
-
-.menuitemsidebar:hover {
-	width: 143px;
-	height: 40px;
-	background: url("../images/mainSidebarOver.png")  no-repeat;
-}
-.menuitemsidebarlong:hover {
+.menuitemsidebar:hover, .menuitemsidebarlong:hover {
 	width: 143px;
 	height: 40px;
 	background: url("../images/mainSidebarOver.png")  no-repeat;
 }
 
-.menuitemsidebar img {
+.menuitemsidebar img, .menuitemsidebarlong img {
 	float: right;
 	position: relative;
 	pointer-events: none;
@@ -128,23 +113,21 @@ form {
 	margin-right: 10px;
 }
 .menuitemsidebarlong img {
-	float: right;
-	position: relative;
-	pointer-events: none;
 	margin-top: -32px;
 	margin-right: 10px;
 }
 
-.menuitemsidebar a {
+.menuitemsidebar a, .menuitemsidebarlong a  {
 	font-weight: bold;
 	color: #FFFFFF;
 	display:inline-block;
 	width:100%;
 	height:80%;
 	text-shadow: 2px 2px #222222;
+	z-index: 1000;
+
 	padding-top: 9px;
 	padding-left: 8px;
-	z-index: 1000;
 }
 
 .menuitemsidebar a:hover, .menuitemsidebar a:active {
@@ -152,15 +135,8 @@ form {
 }
 
 .menuitemsidebarlong a {
-	font-weight: bold;
-	color: #FFFFFF;
-	display:inline-block;
-	width:100%;
-	height:80%;
-	text-shadow: 2px 2px #222222;
 	padding-top: 0px;
 	padding-left: 8px;
-	z-index: 1000;
 }
 
 .menuitemsidebarlong a span {

--- a/template/2/css/style.css
+++ b/template/2/css/style.css
@@ -1,3 +1,5 @@
+* { box-sizing: border-box ;}
+
 html {
 	scroll-behavior: smooth;
 }
@@ -109,12 +111,6 @@ form {
 	float: right;
 	position: relative;
 	pointer-events: none;
-	margin-top: -8px;
-	margin-right: 10px;
-}
-.menuitemsidebarlong img {
-	margin-top: -32px;
-	margin-right: 10px;
 }
 
 .menuitemsidebar a, .menuitemsidebarlong a  {
@@ -122,29 +118,17 @@ form {
 	color: #FFFFFF;
 	display:inline-block;
 	width:100%;
-	height:80%;
+	height: 35px;
 	text-shadow: 2px 2px #222222;
 	z-index: 1000;
-
-	padding-top: 9px;
+	
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
 	padding-left: 8px;
 }
 
 .menuitemsidebar a:hover, .menuitemsidebar a:active {
-	text-decoration: none;
-}
-
-.menuitemsidebarlong a {
-	padding-top: 0px;
-	padding-left: 8px;
-}
-
-.menuitemsidebarlong a span {
-	width: 60%;
-	display: block;
-}
-
-.menuitemsidebarlong a:hover, .menuitemsidebarlong a:active {
 	text-decoration: none;
 }
 

--- a/template/3/css/style.css
+++ b/template/3/css/style.css
@@ -75,11 +75,7 @@ form {
 	margin-bottom: 1px;
 }
 
-.menuitemsidebar img {
-	display: none;
-}
-
-.menuitemsidebarlong img {
+.menuitemsidebar img, .menuitemsidebarlong img {
 	display: none;
 }
 

--- a/template/4/css/style.css
+++ b/template/4/css/style.css
@@ -111,11 +111,7 @@ form {
 	margin-bottom: 1px;
 }
 
-.menuitemsidebar img {
-	display: none;
-}
-
-.menuitemsidebarlong img {
+.menuitemsidebar img, .menuitemsidebarlong img {
 	display: none;
 }
 

--- a/template/5/css/style.css
+++ b/template/5/css/style.css
@@ -73,11 +73,7 @@ form {
 	margin-bottom: 1px;
 }
 
-.menuitemsidebar img {
-	display: none;
-}
-
-.menuitemsidebarlong img {
+.menuitemsidebar img, .menuitemsidebarlong img {
 	display: none;
 }
 

--- a/template/6/css/style.css
+++ b/template/6/css/style.css
@@ -78,11 +78,7 @@ form {
 	margin-bottom: 1px;
 }
 
-.menuitemsidebar img {
-	display: none;
-}
-
-.menuitemsidebarlong img {
+.menuitemsidebar img, .menuitemsidebarlong img {
 	display: none;
 }
 

--- a/template/7/css/style.css
+++ b/template/7/css/style.css
@@ -71,11 +71,7 @@ form {
 	margin-bottom: 1px;
 }
 
-.menuitemsidebar img {
-	display: none;
-}
-
-.menuitemsidebarlong img {
+.menuitemsidebar img, .menuitemsidebarlong img {
 	display: none;
 }
 

--- a/template/8/css/style.css
+++ b/template/8/css/style.css
@@ -97,7 +97,7 @@ form {
 	font-size: 14px;
 }
 
-.menuitemsidebar {
+.menuitemsidebar, .menuitemsidebarlong {
 	width: 143px;
 	height: 40px;
 	margin-top: 1px;
@@ -107,28 +107,13 @@ form {
 	transition: background-image 0.125s ease-in-out;
 }
 
-.menuitemsidebarlong {
-	width: 143px;
-	height: 40px;
-	margin-top: 1px;
-	background: url("../images/mainSidebar.png")  no-repeat;
-	-webkit-transition: background-image 0.125s ease-in-out;
-	-o-transition: background-image 0.125s ease-in-out;
-	transition: background-image 0.125s ease-in-out;
-}
-
-.menuitemsidebar:hover {
-	width: 143px;
-	height: 40px;
-	background: url("../images/mainSidebarOver.png")  no-repeat;
-}
-.menuitemsidebarlong:hover {
+.menuitemsidebar:hover, .menuitemsidebarlong:hover {
 	width: 143px;
 	height: 40px;
 	background: url("../images/mainSidebarOver.png")  no-repeat;
 }
 
-.menuitemsidebar img {
+.menuitemsidebar img, .menuitemsidebarlong img {
 	float: right;
 	position: relative;
 	pointer-events: none;
@@ -136,9 +121,6 @@ form {
 	margin-right: 10px;
 }
 .menuitemsidebarlong img {
-	float: right;
-	position: relative;
-	pointer-events: none;
 	margin-top: -32px;
 	margin-right: 10px;
 }

--- a/template/9/css/style.css
+++ b/template/9/css/style.css
@@ -106,17 +106,7 @@ form {
 	font-weight: 300;
 }
 
-.menuitemsidebar {
-	width: 168px;
-	height: 48px;
-	margin-top: 1px;
-	background-color: #e7e7e7;
-	-webkit-transition: background-color 0.125s ease-in-out;
-	-o-transition: background-color 0.125s ease-in-out;
-	transition: background-color 0.125s ease-in-out;
-}
-
-.menuitemsidebarlong {
+.menuitemsidebar, .menuitemsidebarlong {
 	width: 168px;
 	height: 48px;
 	margin-top: 1px;
@@ -131,40 +121,28 @@ form {
 	height: 48px;
 }
 
-.menuitemsidebar:hover {
-	background-color: #E60012;
-}
-.menuitemsidebarlong:hover {
+.menuitemsidebar:hover, .menuitemsidebarlong:hover {
 	background-color: #E60012;
 }
 
-.menuitemsidebar img {
+.menuitemsidebar img, .menuitemsidebarlong img {
 	float: right;
 	position: relative;
 	pointer-events: none;
-	margin-top: -4px;
-	margin-right: 10px;
 	filter: brightness(0);
 	-webkit-transition: filter 0.125s ease-in-out;
 	-o-transition: filter 0.125s ease-in-out;
 	transition: filter 0.125s ease-in-out;
+	
+	margin-top: -4px;
+	margin-right: 10px;
 }
-.menuitemsidebar:hover img {
+.menuitemsidebar:hover img, .menuitemsidebarlong:hover img {
 	filter: brightness(1);
 }
 .menuitemsidebarlong img {
-	float: right;
-	position: relative;
-	pointer-events: none;
 	margin-top: -40px;
 	margin-right: 10px;
-	filter: brightness(0);
-	-webkit-transition: filter 0.125s ease-in-out;
-	-o-transition: filter 0.125s ease-in-out;
-	transition: filter 0.125s ease-in-out;
-}
-.menuitemsidebarlong:hover img {
-	filter: brightness(1);
 }
 
 .menuitemsidebar a {


### PR DESCRIPTION
Two commits:

1) Reduce duplication between `menuitemsidebar` and `menuitemsidebarlong` to prepare for the removal of `menuitemsidebarlong`
2) Changes icon alignment strategy to flexbox on 2's skin.

If this looks good on all devices, we can roll out these changes to all skins and remove `menuitemsidebarlong`.

![image](https://github.com/user-attachments/assets/665a426e-6eb3-4eac-a398-880726c631c5)
